### PR TITLE
UI changes to the frontend repo

### DIFF
--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -697,11 +697,17 @@ function Modal({ type, isOpen, data, closeModal, openModal }) {
                   </div>
                   <div className="mt-2">
                     <p className="text-sm text-gray-900"> Address</p>
-                    <p className="text-sm text-gray-500">
-                      <a href={data.explorer} target="_blank" rel="noreferrer">
-                        {data.id}
-                      </a>
-                    </p>
+                    <code>
+                      <p className="text-xs text-gray-500">
+                        <a
+                          href={data.explorer}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {data.id}
+                        </a>
+                      </p>
+                    </code>
                   </div>
 
                   <div className="mt-2">
@@ -709,18 +715,18 @@ function Modal({ type, isOpen, data, closeModal, openModal }) {
                     <p className="text-sm text-gray-500">{data.description}</p>
                   </div>
                   <div className="mt-2">
-                    <p className="text-sm text-gray-900"> Website</p>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-900">
+                      {' '}
                       <a href={data.website} target="_blank" rel="noreferrer">
-                        {data.website}
+                        Website→
                       </a>
-                    </p>{' '}
+                    </p>
                   </div>
 
                   <div className="mt-10 flex items-center justify-center">
                     <button
                       type="button"
-                      className="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                      className="inline-flex justify-center rounded-md border border-transparent bg-violet-100 px-4 py-2 text-sm font-medium text-violet-700 hover:bg-violet-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2"
                       onClick={closeModal}
                     >
                       Got it, thanks!

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -16,11 +16,11 @@
   src: url('../fonts/Inter-italic.var.woff2') format('woff2');
 }
 
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* Add consistent color for hyper links */
 a {
   color: #7a53ee;
 }
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -16,6 +16,11 @@
   src: url('../fonts/Inter-italic.var.woff2') format('woff2');
 }
 
+/* Add consistent color for hyper links */
+a {
+  color: #7a53ee;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
This PR introduces a few style changes to the `/frontend` repo

From the screenshot below, I see a few things I wanted to improve

* Address is overflowing from the modal card
* `Got it, thanks!` CTA is inconsistent with the color scheme of the landing page
* `Website` and `Address` being links can have a different color to improve the significance

<img src="https://user-images.githubusercontent.com/9695866/197224396-1579c2db-4440-4682-acdf-ebc6414b0ce6.jpg" width="30%" />

**`Current changes`**

Please find the screenshot which reflects the changes in this PR.

* `Address` has been made smaller and wrapped with `code` tag to make it look significant
* `Got it, thanks!` CTA has been updated to a color consistent with the website palette
* `Website` has been put into a single link for better usability

<img width="30%" src="https://user-images.githubusercontent.com/9695866/197226228-c398944c-f8fb-4af7-a1f9-3bd1124c149d.png">
